### PR TITLE
Datepicker

### DIFF
--- a/tests/ios/test_datepicker.py
+++ b/tests/ios/test_datepicker.py
@@ -1,0 +1,25 @@
+import pytest
+from conftest_ios import test_setup_ios
+from screens.iOS.homeScreen import HomeScreen as onHomeScreen
+from screens.iOS.datepickerViewScreen import DatePickerViewsScreen as onDatePickerViewsScreen
+
+
+"""
+IOS APP DATE PICKER
+"""
+
+
+@pytest.mark.usefixtures('test_setup_ios')
+class TestDatePickerViews:
+    def test_current_date_and_time(self):
+        onHomeScreen.select_option(self, 'Date Picker')
+        onDatePickerViewsScreen.confirm_date_and_time(self)
+        
+    def test_change_current_date(self):
+        onHomeScreen.select_option(self, 'Date Picker')
+        onDatePickerViewsScreen.set_new_date(self)
+     
+    @pytest.mark.skip(reason="time picker is not getting clicked")    
+    def test_change_current_time(self):
+        onHomeScreen.select_option(self, 'Date Picker')
+        onDatePickerViewsScreen.set_new_time(self)


### PR DESCRIPTION
**Scope**
Test for Datepicker

Dates are problematic, and worse when they are the Accessibility ID for the element to be interacted with. My solution was to employ the following modules and set the accessibility ID to reflect the current date. Results = effective!

`from datetime import datetime
from datetime import timedelta, date
import pytz


east_coast = pytz.timezone('America/New_York')  # src: https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568
current_date = datetime.now(east_coast).strftime('%B %d, %Y')
current_time = datetime.now(east_coast).strftime('%I:%M %p')
`